### PR TITLE
Add PHPUnit

### DIFF
--- a/defaultTests/phpunit/ExampleClass.php
+++ b/defaultTests/phpunit/ExampleClass.php
@@ -1,0 +1,36 @@
+<?php
+// MIT License
+
+// Copyright (c) 2021 ArcTouch LLC
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+class ExampleClass
+{
+  private $puppies = ["Lassie", "Lala", "Nala", "Thor", "Bud", "Marley"];
+
+  public function createPuppy() {
+    $index = array_rand($this->puppies);
+    return $this->puppies[$index];
+  }
+
+  public function praisePuppy($puppy, $noun = "dog") {
+    return "$puppy is a good $noun";
+  }
+}

--- a/defaultTests/phpunit/bootstrap.php
+++ b/defaultTests/phpunit/bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+
+// MIT License
+
+// Copyright (c) 2021 ArcTouch LLC
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+spl_autoload_register(function ($class_name) {
+    $source = $class_name . '.php';
+    if (file_exists($source)) {
+        require_once $source;
+    }
+});

--- a/defaultTests/phpunit/phpunit.xml
+++ b/defaultTests/phpunit/phpunit.xml
@@ -1,0 +1,2 @@
+<phpunit bootstrap="./bootstrap.php">
+</phpunit>

--- a/defaultTests/phpunit/tests/ExampleClassTest.php
+++ b/defaultTests/phpunit/tests/ExampleClassTest.php
@@ -1,0 +1,56 @@
+<?php
+// MIT License
+
+// Copyright (c) 2021 ArcTouch LLC
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleClassTest extends TestCase
+{
+
+    protected $instance;
+
+    protected function setUp() {
+        $this->instance = new ExampleClass();
+    }
+
+    public function testCreatePuppy() {
+        $puppy = $this->instance->createPuppy();
+        $this->assertTrue(is_string($puppy));
+        return $puppy;
+    }
+
+    /**
+     * @depends testCreatePuppy
+     */
+    public function testPraisePuppy($puppy) {
+        $praise = $this->instance->praisePuppy($puppy);
+        $praiseGirl = $this->instance->praisePuppy($puppy, "girl");
+        $praiseBoy = $this->instance->praisePuppy($puppy, "boy");
+
+        $expected = "$puppy is a good dog";
+        $expectedGirl = "$puppy is a good girl";
+        $expectedBoy = "$puppy is a good boy";
+        $this->assertEquals($expected, $praise);
+        $this->assertEquals($expectedGirl, $praiseGirl);
+        $this->assertEquals($expectedBoy, $praiseBoy);
+    }
+}

--- a/testsFactory.sh
+++ b/testsFactory.sh
@@ -192,6 +192,58 @@ XUNIT_EXAMPLE="<Project Sdk=\"Microsoft.NET.Sdk\">
 </Project>
 "
 
+PHPUNIT_TEST="<?php
+use PHPUnit\Framework\TestCase;
+
+class ExampleClassTest extends TestCase
+{
+
+    protected \$instance;
+
+    protected function setUp() {
+        \$this->instance = new ExampleClass();
+    }
+
+    public function testCreatePuppy() {
+        \$puppy = \$this->instance->createPuppy();
+        \$this->assertTrue(is_string(\$puppy));
+        return \$puppy;
+    }
+
+    /**
+     * @depends testCreatePuppy
+     */
+    public function testPraisePuppy(\$puppy) {
+        \$praise = \$this->instance->praisePuppy(\$puppy);
+        \$praiseGirl = \$this->instance->praisePuppy(\$puppy, \"girl\");
+        \$praiseBoy = \$this->instance->praisePuppy(\$puppy, \"boy\");
+
+        \$expected = \"\$puppy is a good dog\";
+        \$expectedGirl = \"\$puppy is a good girl\";
+        \$expectedBoy = \"\$puppy is a good boy\";
+        \$this->assertEquals(\$expected, \$praise);
+        \$this->assertEquals(\$expectedGirl, \$praiseGirl);
+        \$this->assertEquals(\$expectedBoy, \$praiseBoy);
+    }
+}
+"
+
+PHPUNIT_EXAMPLE="<?php
+class ExampleClass
+{
+  private \$puppies = [\"Lassie\", \"Lala\", \"Nala\", \"Thor\", \"Bud\", \"Marley\"];
+
+  public function createPuppy() {
+    \$index = array_rand(\$this->puppies);
+    return \$this->puppies[\$index];
+  }
+
+  public function praisePuppy(\$puppy, \$noun = \"dog\") {
+    return \"\$puppy is a good \$noun\";
+  }
+}
+"
+
 echo -e \
 """
 Hello, Welcome to ${ORANGE}Tests Factory${NC}!
@@ -205,6 +257,7 @@ echo -e \
 3. Rspec
 4. Go
 5. xUnit
+6. PHPUnit
 """
 
 echo -ne "${RED}Select Framework >>${NC} "
@@ -284,6 +337,17 @@ elif [[ $FRAMEWORK_REFERENCE_NUMBER == "5" ]]; then
   FRAMEWORK_MOCK=${XUNIT_MOCK}
   FRAMEWORK_TEST=${XUNIT_TEST}
   INIT_CONTENT=${XUNIT_EXAMPLE}
+elif [[ $FRAMEWORK_REFERENCE_NUMBER == "6" ]]; then
+  FRAMEWORK_NAME="phpunit"
+
+  TEST_FOLDER="tests"
+
+  TEST_FILE="tests/${FILE_NAME}Test.php"
+  INIT_FILE="tests/${FILE_NAME}.php"
+
+  FRAMEWORK_TEST=${PHPUNIT_TEST}
+  INIT_CONTENT=${PHPUNIT_EXAMPLE}
+  FRAMEWORK_MOCK_WARNING="https://phpunit.readthedocs.io/en/9.5/test-doubles.html"
 fi
 
 ## Insert new folder and tests
@@ -294,9 +358,19 @@ ${ORANGE}##${NC} Create new ${TEST_FOLDER} folder $(mkdir ${TEST_FOLDER})
 ${ORANGE}###${NC} Create new ${TEST_MOCK_FOLDER} folder $(mkdir ${TEST_MOCK_FOLDER})
 ${ORANGE}####${NC} Insert default test on tests folder \
 $(echo "${FRAMEWORK_TEST}" >> ${TEST_FILE}) \
-${ORANGE}#####${NC} Insert default mock on tests/mocks folder \
-$(echo "${FRAMEWORK_MOCK}" >> ${MOCK_FILE}) \
+"""
+if [ -z ${FRAMEWORK_MOCK+x} ]; then
+  echo "${FRAMEWORK_NAME} doesn't have mock files: ${FRAMEWORK_MOCK_WARNING}";
+else
+  echo -e \
+  """
+  ${ORANGE}#####${NC} Insert default mock on tests/mocks folder \
+  $(echo "${FRAMEWORK_MOCK}" >> ${MOCK_FILE}) \
+  """
+fi
 
+echo -e \
+"""
 $(echo "${INIT_CONTENT}" >> ${INIT_FILE}) \
 
 ${GREEN}##############################${NC}


### PR DESCRIPTION
I've changed the base script a little, because PHPUnit [doesn't use regular mockfiles](https://phpunit.readthedocs.io/en/9.5/test-doubles.html). Some people would say that maybe [fixtures](https://blog.theodo.com/2013/08/managing-fixtures/) would be equivalent here, but I believe it's not an exact equivalency and out of the current scope of this project.